### PR TITLE
Update to latest sequelize api

### DIFF
--- a/lib/express-session-sequelize.js
+++ b/lib/express-session-sequelize.js
@@ -35,7 +35,7 @@ module.exports = (Store) => {
 		get(sid, callback) {
 			const Session = this.Session;
 			return Session
-				.findById(sid)
+				.findbyPk(sid)
 				.then(session => {
 					if (session && session.data) {
 						return JSON.parse(session.data);
@@ -58,7 +58,7 @@ module.exports = (Store) => {
 
 			realData.expires = expires;
 
-			return Session.findById(sid)
+			return Session.findbyPk(sid)
 				.then(session => {
 					if (session) {
 						session.data = JSON.stringify(realData);
@@ -80,7 +80,7 @@ module.exports = (Store) => {
 
 		destroy(sid, callback) {
 			const Session = this.Session;
-			return Session.findById(sid)
+			return Session.findbyPk(sid)
 				.then(session => {
 					if (session) {
 						return session.destroy();

--- a/lib/express-session-sequelize.js
+++ b/lib/express-session-sequelize.js
@@ -35,7 +35,7 @@ module.exports = (Store) => {
 		get(sid, callback) {
 			const Session = this.Session;
 			return Session
-				.findbyPk(sid)
+				.findByPk(sid)
 				.then(session => {
 					if (session && session.data) {
 						return JSON.parse(session.data);
@@ -58,7 +58,7 @@ module.exports = (Store) => {
 
 			realData.expires = expires;
 
-			return Session.findbyPk(sid)
+			return Session.findByPk(sid)
 				.then(session => {
 					if (session) {
 						session.data = JSON.stringify(realData);
@@ -80,7 +80,7 @@ module.exports = (Store) => {
 
 		destroy(sid, callback) {
 			const Session = this.Session;
-			return Session.findbyPk(sid)
+			return Session.findByPk(sid)
 				.then(session => {
 					if (session) {
 						return session.destroy();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "chai": "^3.5.0",
     "express-session": "^1.14.1",
     "mocha": "^3.0.2",
-    "sequelize": "^3.24.3",
+    "sequelize": "^4.41.0",
     "sinon": "^1.17.6",
     "sqlite3": "^3.1.4"
   }

--- a/test/express-session-sequelizeTest.js
+++ b/test/express-session-sequelizeTest.js
@@ -103,7 +103,7 @@ describe('express-session-sequelize', () => {
 
 		it('creates a session model from input data', () => {
 			return sessionStore.set('test777', {}, () => {})
-				.then(() => sessionStore.Session.findById('test777'))
+				.then(() => sessionStore.Session.findByPk('test777'))
 				.then(session => expect(session).to.not.equal.null);
 		});
 	});
@@ -137,7 +137,7 @@ describe('express-session-sequelize', () => {
 
 		it('removes session with matching session_id from database', () => {
 			return sessionStore.destroy('test777', () => {})
-				.then(() => sessionStore.Session.findById('test777'))
+				.then(() => sessionStore.Session.findByPk('test777'))
 				.then(session => expect(session).to.equal.null);
 		});
 	});
@@ -171,7 +171,7 @@ describe('express-session-sequelize', () => {
 
 		it('updates expiration date of session', () => {
 			return sessionStore.touch('test777', {}, () => {})
-				.then(() => sessionStore.Session.findById('test777'))
+				.then(() => sessionStore.Session.findByPk('test777'))
 				.then(session => expect(session).to.have
 					.property('expires').and.to.be.greaterThan(Date.now()));
 		});


### PR DESCRIPTION
Stops the following warning:
`sequelize deprecated Model.findById has been deprecated, please use Model.findByPk instead`