### PR TITLE
Replace the deprecated sequelize.import with require

### DIFF
--- a/lib/express-session-sequelize.js
+++ b/lib/express-session-sequelize.js
@@ -70,7 +70,7 @@ module.exports = (Store) => {
 			super(realOptions);
 
 			this.options = realOptions;
-			this.Session = options.db.import(path.join(__dirname, 'models', 'Session'));
+			this.Session = require(path.join(__dirname, 'models', 'Session'))(options.db)
 			this.Session.sync();
 			this.startExpiringSessions();
 		}

--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,10 +1,12 @@
-module.exports = (sequelize, DataTypes) => {
+const { Sequelize } = require("sequelize")
+
+module.exports = (sequelize) => {
 	return sequelize.define('Session', {
 		'session_id': {
-			type: DataTypes.STRING(32),
+			type: Sequelize.DataTypes.STRING(32),
 			primaryKey: true,
 		},
-		expires: DataTypes.DATE,
-		data: DataTypes.TEXT,
+		expires: Sequelize.DataTypes.DATE,
+		data: Sequelize.DataTypes.TEXT,
 	});
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-session-sequelize",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Express session store using Sequelize to persist session data.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The repo currently doesn't work with v6 beta since it relies on the deprecated `sequelize.import`. This replaces that with `require`.