### PR TITLE
Get Sequelize reference from instance

### DIFF
--- a/lib/models/Session.js
+++ b/lib/models/Session.js
@@ -1,6 +1,6 @@
-const { Sequelize } = require("sequelize")
-
 module.exports = (sequelize) => {
+	const { Sequelize } = sequelize;
+
 	return sequelize.define('Session', {
 		'session_id': {
 			type: Sequelize.DataTypes.STRING(32),


### PR DESCRIPTION
With sequelize v7 being released under `@sequelize/core` relying on the "sequelize" dependency is no longer going to be stable. Instead we can retrieve the constructor from the instance itself.